### PR TITLE
Add unique_id to sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ sensor:
     host: YOUR_SENSOR_IP
     token: YOUR_SENSOR_TOKEN
     name: YOUT_SENSOR_NAME
+    unique_id: YOUR_UNIQUE_ID
 ```

--- a/custom_components/mi_water_purifier/sensor.py
+++ b/custom_components/mi_water_purifier/sensor.py
@@ -34,28 +34,29 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         device = Device(host, token)
         waterPurifier = XiaomiWaterPurifier(device, name, unique_id)
         devices.append(waterPurifier)
-        devices.append(XiaomiWaterPurifierSensor(waterPurifier, TAP_WATER_QUALITY))
-        devices.append(XiaomiWaterPurifierSensor(waterPurifier, FILTERED_WATER_QUALITY))
-        devices.append(XiaomiWaterPurifierSensor(waterPurifier, PP_COTTON_FILTER_REMAINING))
-        devices.append(XiaomiWaterPurifierSensor(waterPurifier, FRONT_ACTIVE_CARBON_FILTER_REMAINING))
-        devices.append(XiaomiWaterPurifierSensor(waterPurifier, RO_FILTER_REMAINING))
-        devices.append(XiaomiWaterPurifierSensor(waterPurifier, REAR_ACTIVE_CARBON_FILTER_REMAINING))
+        devices.append(XiaomiWaterPurifierSensor(waterPurifier, TAP_WATER_QUALITY, unique_id))
+        devices.append(XiaomiWaterPurifierSensor(waterPurifier, FILTERED_WATER_QUALITY, unique_id))
+        devices.append(XiaomiWaterPurifierSensor(waterPurifier, PP_COTTON_FILTER_REMAINING, unique_id))
+        devices.append(XiaomiWaterPurifierSensor(waterPurifier, FRONT_ACTIVE_CARBON_FILTER_REMAINING, unique_id))
+        devices.append(XiaomiWaterPurifierSensor(waterPurifier, RO_FILTER_REMAINING, unique_id))
+        devices.append(XiaomiWaterPurifierSensor(waterPurifier, REAR_ACTIVE_CARBON_FILTER_REMAINING, unique_id))
     except DeviceException:
         _LOGGER.exception('Fail to setup Xiaomi water purifier')
         raise PlatformNotReady
 
     add_devices(devices)
 
+
 class XiaomiWaterPurifierSensor(Entity):
     """Representation of a XiaomiWaterPurifierSensor."""
 
-    def __init__(self, waterPurifier, data_key):
+    def __init__(self, waterPurifier, data_key, unique_id):
         """Initialize the XiaomiWaterPurifierSensor."""
         self._state = None
         self._data = None
         self._waterPurifier = waterPurifier
         self._data_key = data_key
-        self._attr_unique_id = 'MI_WATER_PURIFIER_' + data_key['key']
+        self._attr_unique_id = unique_id + '_' + data_key['key']
         self.parse_data()
 
     @property
@@ -67,7 +68,7 @@ class XiaomiWaterPurifierSensor(Entity):
     def icon(self):
         """Icon to use in the frontend, if any."""
         if self._data_key['key'] is TAP_WATER_QUALITY['key'] or \
-           self._data_key['key'] is FILTERED_WATER_QUALITY['key']:
+                self._data_key['key'] is FILTERED_WATER_QUALITY['key']:
             return 'mdi:water'
         else:
             return 'mdi:filter-outline'
@@ -81,7 +82,7 @@ class XiaomiWaterPurifierSensor(Entity):
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         if self._data_key['key'] is TAP_WATER_QUALITY['key'] or \
-           self._data_key['key'] is FILTERED_WATER_QUALITY['key']:
+                self._data_key['key'] is FILTERED_WATER_QUALITY['key']:
             return 'TDS'
         return '%'
 
@@ -91,9 +92,9 @@ class XiaomiWaterPurifierSensor(Entity):
         attrs = {}
 
         if self._data_key['key'] is PP_COTTON_FILTER_REMAINING['key'] or \
-           self._data_key['key'] is FRONT_ACTIVE_CARBON_FILTER_REMAINING['key'] or \
-           self._data_key['key'] is RO_FILTER_REMAINING['key'] or \
-           self._data_key['key'] is REAR_ACTIVE_CARBON_FILTER_REMAINING['key']:
+                self._data_key['key'] is FRONT_ACTIVE_CARBON_FILTER_REMAINING['key'] or \
+                self._data_key['key'] is RO_FILTER_REMAINING['key'] or \
+                self._data_key['key'] is REAR_ACTIVE_CARBON_FILTER_REMAINING['key']:
             attrs[self._data_key['name']] = '{} days remaining'.format(self._data[self._data_key['days_key']])
 
         return attrs
@@ -106,6 +107,7 @@ class XiaomiWaterPurifierSensor(Entity):
     def update(self):
         """Get the latest data and updates the states."""
         self.parse_data()
+
 
 class XiaomiWaterPurifier(Entity):
     """Representation of a XiaomiWaterPurifier."""
@@ -149,9 +151,11 @@ class XiaomiWaterPurifier(Entity):
         attrs = {}
         attrs[TAP_WATER_QUALITY['name']] = '{}TDS'.format(self._data[TAP_WATER_QUALITY['key']])
         attrs[PP_COTTON_FILTER_REMAINING['name']] = '{}%'.format(self._data[PP_COTTON_FILTER_REMAINING['key']])
-        attrs[FRONT_ACTIVE_CARBON_FILTER_REMAINING['name']] = '{}%'.format(self._data[FRONT_ACTIVE_CARBON_FILTER_REMAINING['key']])
+        attrs[FRONT_ACTIVE_CARBON_FILTER_REMAINING['name']] = '{}%'.format(
+            self._data[FRONT_ACTIVE_CARBON_FILTER_REMAINING['key']])
         attrs[RO_FILTER_REMAINING['name']] = '{}%'.format(self._data[RO_FILTER_REMAINING['key']])
-        attrs[REAR_ACTIVE_CARBON_FILTER_REMAINING['name']] = '{}%'.format(self._data[REAR_ACTIVE_CARBON_FILTER_REMAINING['key']])
+        attrs[REAR_ACTIVE_CARBON_FILTER_REMAINING['name']] = '{}%'.format(
+            self._data[REAR_ACTIVE_CARBON_FILTER_REMAINING['key']])
 
         return attrs
 

--- a/custom_components/mi_water_purifier/sensor.py
+++ b/custom_components/mi_water_purifier/sensor.py
@@ -2,7 +2,7 @@
 import math
 import logging
 
-from homeassistant.const import (CONF_NAME, CONF_HOST, CONF_TOKEN, )
+from homeassistant.const import (CONF_NAME, CONF_HOST, CONF_TOKEN, CONF_UNIQUE_ID)
 from homeassistant.helpers.entity import Entity
 from homeassistant.exceptions import PlatformNotReady
 from miio import Device, DeviceException
@@ -25,13 +25,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
     token = config.get(CONF_TOKEN)
+    unique_id = config.get(CONF_UNIQUE_ID)
 
     _LOGGER.info("Initializing Xiaomi water purifier with host %s (token %s...)", host, token[:5])
 
     devices = []
     try:
         device = Device(host, token)
-        waterPurifier = XiaomiWaterPurifier(device, name)
+        waterPurifier = XiaomiWaterPurifier(device, name, unique_id)
         devices.append(waterPurifier)
         devices.append(XiaomiWaterPurifierSensor(waterPurifier, TAP_WATER_QUALITY))
         devices.append(XiaomiWaterPurifierSensor(waterPurifier, FILTERED_WATER_QUALITY))
@@ -54,6 +55,7 @@ class XiaomiWaterPurifierSensor(Entity):
         self._data = None
         self._waterPurifier = waterPurifier
         self._data_key = data_key
+        self._attr_unique_id = 'MI_WATER_PURIFIER_' + data_key['key']
         self.parse_data()
 
     @property
@@ -108,11 +110,12 @@ class XiaomiWaterPurifierSensor(Entity):
 class XiaomiWaterPurifier(Entity):
     """Representation of a XiaomiWaterPurifier."""
 
-    def __init__(self, device, name):
+    def __init__(self, device, name, unique_id):
         """Initialize the XiaomiWaterPurifier."""
         self._state = None
         self._device = device
         self._name = name
+        self._attr_unique_id = unique_id
         self.parse_data()
 
     @property


### PR DESCRIPTION
Sensors cannot be controlled via the HomeAssistant web UI if they do not have unique IDs. This PR adds unique IDs for all entities created, so that you can assign sensors to area.